### PR TITLE
Fix nixpacks build: bump better-sqlite3 to ^12 for Node 24 prebuilds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@simplewebauthn/server": "^11.0.0",
         "@turf/turf": "^7.2.0",
         "@vueuse/core": "^13.2.0",
-        "better-sqlite3": "^11.7.0",
+        "better-sqlite3": "^12.11.1",
         "consola": "^3.4.0",
         "date-fns": "^4.1.0",
         "drizzle-kit": "^0.31.1",
@@ -61,7 +61,7 @@
         "workbox-precaching": "^7.3.0"
       },
       "engines": {
-        "node": "22"
+        "node": "24"
       }
     },
     "node_modules/@adonisjs/hash": {
@@ -10141,14 +10141,17 @@
       }
     },
     "node_modules/better-sqlite3": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
-      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/bignumber.js": {
@@ -13197,20 +13200,6 @@
       },
       "engines": {
         "node": ">=22"
-      }
-    },
-    "node_modules/gtfs/node_modules/better-sqlite3": {
-      "version": "12.11.1",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
-      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
-      },
-      "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/gzip-size": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@simplewebauthn/server": "^11.0.0",
     "@turf/turf": "^7.2.0",
     "@vueuse/core": "^13.2.0",
-    "better-sqlite3": "^11.7.0",
+    "better-sqlite3": "^12.11.1",
     "consola": "^3.4.0",
     "date-fns": "^4.1.0",
     "drizzle-kit": "^0.31.1",
@@ -85,7 +85,6 @@
     "esbuild@0.28.1": true,
     "esbuild@0.25.12": true,
     "@parcel/watcher@2.5.6": true,
-    "better-sqlite3@11.10.0": true,
     "better-sqlite3@12.11.1": true,
     "fsevents@2.3.3": true,
     "sharp@0.32.6": true


### PR DESCRIPTION
## Problem

The nixpacks build fails in CI (and locally) during the **install** phase — before `npm run build` ever runs:

```
npm error path /app/node_modules/better-sqlite3
npm error gyp ERR! find Python ... Could not find any Python installation to use
ERROR: process "/bin/bash -ol pipefail -c npm ci" did not complete successfully: exit code: 1
```

## Root cause

The Node **22 → 24** bump (#208–#210) updated `engines.node`, `.node-version`, and `nixpacks.toml` (`nodejs_22` → `nodejs_24`) but left `better-sqlite3` at `^11.7.0`, which resolves to **11.10.0**. That version ships **no prebuilt binary for Node 24** (ABI `node-v137`) — confirmed against its GitHub releases for both `linux-x64` (CI) and `darwin-arm64` (local). With no prebuild, `npm ci` falls back to `node-gyp`, which fails because the `railwayapp/nixpacks:ubuntu` build image has **no Python**. Same failure path locally on Node 24.

(`gtfs`'s nested `better-sqlite3@12.11.1` installed fine because **v12 added Node 24 to its prebuild matrix**.)

## Fix

Bump root `better-sqlite3` `^11.7.0` → **`^12.11.1`**. v12.0.0's only breaking change was dropping EOL Node 18 — no JS API changes, and the code uses only the stable surface (`new Database(...)`, `drizzle-orm/better-sqlite3`). This also dedupes to a single `12.11.1` copy shared with `gtfs`. Removed the now-stale (unused) `allowScripts` entry for `11.10.0`.

## Verification (Node 24.18.0)

- ✅ `npm ci` — the exact command CI failed on — succeeds, no node-gyp / no Python / no compilation
- ✅ `better-sqlite3` loads and runs a query using the downloaded prebuilt binary
- ✅ full `npm run build` → "✨ Build complete!"
- ✅ `better-sqlite3-v12.11.1-node-v137-linux-x64` prebuild exists, so CI on Ubuntu amd64 fetches it too

🤖 Generated with [Claude Code](https://claude.com/claude-code)