### PR TITLE
fix(post): hide report form when broadcast already sent

### DIFF
--- a/components/post.test.ts
+++ b/components/post.test.ts
@@ -1,6 +1,6 @@
 import { vi, it, expect } from "vitest";
 import { mountSuspended, registerEndpoint } from "@nuxt/test-utils/runtime";
-import { Post, ReportSummary } from "#components";
+import { Post, ReportSummary, ReportForm } from "#components";
 import type { SelectReport } from "../db/schema";
 import { faker } from "@faker-js/faker";
 
@@ -71,6 +71,41 @@ it("should show internal report broadcast form if report is from internal source
 //   });
 //   expect(component.find('#external-source-broadcast-form').exists()).toBe(true);
 // });
+
+const externalReport: SelectReport = {
+  id: 456,
+  createdAt: new Date("May 15, 2025 04:00:00"),
+  source: "mastodon",
+  uri: null,
+  reviewedAt: null,
+  route: null,
+  stop: {
+    stopId: "123",
+    stopName: "Mission",
+    direction: "south",
+  },
+  direction: null,
+  passenger: null,
+  message: faker.word.words(8),
+};
+
+it("should show the report form for an unreviewed external-source report", async () => {
+  const component = await mountSuspended(Post, {
+    props: {
+      report: externalReport,
+    },
+  });
+  expect(component.findComponent(ReportForm).exists()).toBe(true);
+});
+
+it("should not show the report form if a broadcast has already been sent", async () => {
+  const component = await mountSuspended(Post, {
+    props: {
+      report: { ...externalReport, reviewedAt: new Date() },
+    },
+  });
+  expect(component.findComponent(ReportForm).exists()).toBe(false);
+});
 
 it("should mark the report as not approved with the API", async () => {
   const mockFetch = vi.spyOn(global, "$fetch");

--- a/components/post.vue
+++ b/components/post.vue
@@ -11,7 +11,7 @@
       <div class="p-2 rounded bg-gray-100 text-gray-600 text-sm mb-4">
         <span>{{ props.report.message }}</span>
       </div>
-      <ReportForm v-model="dummyFormState" class="mb-4" />
+      <ReportForm v-if="!props.report?.reviewedAt" v-model="dummyFormState" class="mb-4" />
     </div>
 
     <div class="p-2 rounded bg-gray-100 text-gray-600 text-sm">


### PR DESCRIPTION
Closes #155

## Problem
For external-source reports, the editable `ReportForm` (the agency/route/stop/passenger selectors) stayed open even after a broadcast had already been sent for the report. Once a broadcast is posted, the server sets the report's `reviewedAt` and the `broadcasts` table enforces a unique `reportId`, so keeping the form open is misleading — no new broadcast can be created for the report.

## Fix
Hide the `ReportForm` when `reviewedAt` is set (i.e., a broadcast has already been sent / the report is reviewed), consistent with the existing footer guard that hides the Post/Dismiss buttons in the same condition. The external report message is still displayed for context.

## Changes
- `components/post.vue`: added `v-if="!props.report?.reviewedAt"` to the `ReportForm`.
- `components/post.test.ts`: added tests covering an unreviewed external-source report (form shown) and a reviewed external-source report (form hidden). Verified the new "hidden" test fails without the fix.