### PR TITLE
feat(notifications): add Post/Dismiss action buttons to push notifications

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -72,16 +72,18 @@ self.addEventListener('notificationclick', (event) => {
   let work;
   switch (event.action) {
     case 'post':
-      // Post immediately; on success there's no follow-up notification. On any
-      // failure (401 expired session, 409 already broadcast, network error)
-      // fall back to opening the app so the reviewer can finish in-app.
+      // Post immediately; on success there's no follow-up notification. A 409
+      // (broadcast already exists for this report) is treated as success since
+      // the desired end state is already reached. On other failures (401 expired
+      // session, network error) fall back to opening the app so the reviewer can
+      // finish in-app.
       work = fetch('/api/broadcasts', {
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ message, reportId }),
       })
-        .then(res => (res.ok ? undefined : openReport(reportUrl)))
+        .then(res => (res.ok || res.status === 409 ? undefined : openReport(reportUrl)))
         .catch(() => openReport(reportUrl));
       break;
     case 'dismiss':

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -7,15 +7,30 @@ self.addEventListener('push', function(event) {
   const promises = [];
 
   switch (pushBody.tag) {
-    case 'new-report':
+    case 'new-report': {
+      // Notification action buttons aren't supported everywhere (notably iOS
+      // Safari). Notification.maxActions is undefined/0 where they're
+      // unsupported; guard with typeof to avoid a ReferenceError in the SW
+      // global scope, and only attach as many buttons as the platform allows.
+      // When no buttons render, the notification still shows and tapping it
+      // opens the app (see the default branch in notificationclick).
+      const maxActions = (typeof Notification !== 'undefined' && Notification.maxActions) || 0;
+      const actions = [];
+      if (maxActions >= 1) actions.push({ action: 'post', title: 'Post' });
+      if (maxActions >= 2) actions.push({ action: 'dismiss', title: 'Dismiss' });
+
       promises.push(
         self.registration.showNotification(pushBody.title, {
           body: pushBody.body,
           // @ts-ignore it exists, type is wrong https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration/showNotification#image
           image: '/android-chrome-192x192.png',
           tag: pushBody.tag,
+          actions,
           data: {
-            reportUrl: pushBody.reportUrl
+            reportUrl: pushBody.reportUrl,
+            // == getPlainTextSummary(report); reused verbatim as the broadcast
+            // message by the 'post' action so no separate lookup is needed.
+            message: pushBody.body,
           }
         })
       );
@@ -23,6 +38,7 @@ self.addEventListener('push', function(event) {
         promises.push(WorkerNavigator.setAppBadge(pushBody.unhandledReportsCount));
       } catch(err) {}
       break;
+    }
     default:
       break;
   }
@@ -30,16 +46,62 @@ self.addEventListener('push', function(event) {
   event.waitUntil(Promise.all(promises));
 });
 
-self.addEventListener('notificationclick', async (event) => {
-  const clickedNotification = event.notification;
-  clickedNotification.close();
-
-  const openingWindow = clients.openWindow(`${event.notification.data.reportUrl}`)
-  .then(windowClient => {
+// Open the report in the app. Used for plain taps and as the graceful fallback
+// when an action's API call fails (e.g. expired session, already handled).
+function openReport(reportUrl) {
+  return clients.openWindow(reportUrl).then(windowClient => {
     if (windowClient) {
       windowClient.focus();
     }
   });
+}
 
-  event.waitUntil(openingWindow);
+// reportUrl is formatted as '/reports/:reportId'; derive the id from it rather
+// than carrying a separate payload field.
+function reportIdFromUrl(reportUrl) {
+  const match = /\/reports\/(\d+)/.exec(reportUrl || '');
+  return match ? match[1] : undefined;
+}
+
+self.addEventListener('notificationclick', (event) => {
+  const notification = event.notification;
+  const { reportUrl, message } = notification.data || {};
+  const reportId = reportIdFromUrl(reportUrl);
+  notification.close();
+
+  let work;
+  switch (event.action) {
+    case 'post':
+      // Post immediately; on success there's no follow-up notification. On any
+      // failure (401 expired session, 409 already broadcast, network error)
+      // fall back to opening the app so the reviewer can finish in-app.
+      work = fetch('/api/broadcasts', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message, reportId }),
+      })
+        .then(res => (res.ok ? undefined : openReport(reportUrl)))
+        .catch(() => openReport(reportUrl));
+      break;
+    case 'dismiss':
+      // Mark the report reviewed without creating a broadcast. The endpoint
+      // only updates rows where reviewedAt is still null, so a double-dismiss
+      // is a harmless no-op.
+      work = fetch(`/api/reports/${reportId}`, {
+        method: 'PUT',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      })
+        .then(res => (res.ok ? undefined : openReport(reportUrl)))
+        .catch(() => openReport(reportUrl));
+      break;
+    default:
+      // Plain tap, or a platform that doesn't render action buttons.
+      work = openReport(reportUrl);
+      break;
+  }
+
+  event.waitUntil(work);
 });

--- a/shared/utils/get-plain-text-summary.ts
+++ b/shared/utils/get-plain-text-summary.ts
@@ -14,15 +14,21 @@ export default function (report: PartialReport) {
 
   const formattedDate = formatDate(report.createdAt, "p");
 
+  let summary;
   if (report.message) {
-    return `${formattedDate}: ${report.message}`;
+    summary = `${formattedDate}: ${report.message}`;
   }
   else if (report.passenger) {
-    return `${formattedDate}: Fare inspectors on ${report.route?.routeShortName || "ROUTE"
+    summary = `${formattedDate}: Fare inspectors on ${report.route?.routeShortName || "ROUTE"
       } (${report.route?.headsign || "HEADSIGN"}) from ${report.stop?.stopName || "STOP"
       }`;
   } else {
-    return `${formattedDate}: Fare inspectors at ${report.stop?.stopName || "STOP"
+    summary = `${formattedDate}: Fare inspectors at ${report.stop?.stopName || "STOP"
       } ${report.stop?.direction || "DIRECTION"}`;
   }
+
+  // Bound the summary to 400 chars so it satisfies the broadcast message
+  // schema (z.string().max(400)). The notification body is reused verbatim
+  // as the broadcast message by the service worker 'post' action.
+  return summary.length > 400 ? summary.slice(0, 400) : summary;
 }

--- a/shared/utils/notify.test.ts
+++ b/shared/utils/notify.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { formatReportAsNotification } from './notify';
+import getPlainTextSummary from './get-plain-text-summary';
+import type { SelectReport } from '../../db/schema';
+
+const report = {
+  id: 42,
+  createdAt: new Date('2026-07-10T12:00:00Z'),
+  source: 'internal',
+  uri: 'https://unfaresf.org/reports/42',
+  route: null,
+  stop: { stopId: '1', stopName: 'Foo Station', direction: 'Northbound' },
+  direction: null,
+  passenger: false,
+  message: 'Fare inspectors spotted at Foo Station',
+  reviewedAt: null,
+} as unknown as SelectReport;
+
+describe('formatReportAsNotification', () => {
+  it('uses the plain-text summary as the body (reused verbatim as the broadcast message)', () => {
+    const detail = formatReportAsNotification(report, 3);
+    expect(detail.body).toBe(getPlainTextSummary(report));
+  });
+
+  it('formats reportUrl as /reports/:reportId (the service worker parses the id back out of it)', () => {
+    const detail = formatReportAsNotification(report, 3);
+    expect(detail.reportUrl).toBe('/reports/42');
+  });
+
+  it('keeps the new-report tag and outstanding count', () => {
+    const detail = formatReportAsNotification(report, 3);
+    expect(detail.tag).toBe('new-report');
+    expect(detail.unhandledReportsCount).toBe(3);
+  });
+});

--- a/shared/utils/notify.ts
+++ b/shared/utils/notify.ts
@@ -55,7 +55,7 @@ async function getSubscriptionsForUsers(userIds:number[]) {
   );
 }
 
-function formatReportAsNotification(reports:SelectReport, totalOutstanding:number):NotificationDetail {
+export function formatReportAsNotification(reports:SelectReport, totalOutstanding:number):NotificationDetail {
   const body = getPlainTextSummary(reports);
 
   return {


### PR DESCRIPTION
Let reviewers act on new-report web-push notifications without opening the app (issue #215).

- service-worker: attach Post/Dismiss actions guarded by Notification.maxActions (degrades to tap-to-open where unsupported, e.g. iOS Safari); branch notificationclick on event.action to POST /api/broadcasts (reusing the notification body as the message) or PUT /api/reports/:id, using the session cookie via credentials:include; fallback to opening the app on failure. reportId is parsed from the reportUrl payload rather than passed explicitly.
- notify: export formatReportAsNotification and add a unit test covering the body and /reports/:reportId url contract the service worker relies on.
