### PR TITLE
Mobile menu refactor

### DIFF
--- a/app/components/notifications.vue
+++ b/app/components/notifications.vue
@@ -1,169 +1,27 @@
 <template>
   <div v-if="supported">
-    <UTooltip v-if="permissionGranted" :text="tooltipText">
-      <UButton v-if="currentSubscription" :loading="loading" color="neutral" variant="outline" class="m-2" icon="i-heroicons-bell" @click="toggleNotifications" />
-      <UButton v-else :loading="loading" color="neutral" variant="outline" class="m-2" icon="i-heroicons-bell-snooze" @click="toggleNotifications" />
-    </UTooltip>
-    <UTooltip v-else text="Enable new report notifications">
-      <UButton :loading="loading" color="primary" class="m-2" icon="i-heroicons-bell-slash" @click="setupNotifications" />
+    <UTooltip :text="tooltipText">
+      <UButton
+        :loading="loading"
+        :color="permissionGranted ? 'neutral' : 'primary'"
+        :variant="permissionGranted ? 'outline' : 'solid'"
+        class="m-2"
+        :icon="bellIcon"
+        @click="toggle"
+      />
     </UTooltip>
   </div>
 </template>
 
 <script setup lang="ts">
-const {public: {vapidPublicKey}} = useRuntimeConfig();
-const { $pwa } = useNuxtApp();
-const toast = useToast();
+import { useNotifications } from '~/composable/useNotifications';
 
-const loading = ref(false);
-const supported = ref<boolean>(isSupported());
-const permissionGranted = ref<boolean>(Notification.permission !== "denied");
-const currentSubscription = shallowRef<PushSubscription|null>(null);
-const tooltipText = computed(() => {
-  return currentSubscription.value ? 'Notifications enabled' : 'Notifications disabled'
-});
-function isSupported() {
-  try {
-    if (!('serviceWorker' in navigator)) {
-      return false;
-    }
-
-    if (!('PushManager' in window)) {
-      return false;
-    }
-
-    if (!("Notification" in window)) {
-      return false;
-    }
-  } catch (err:any) {
-    return false;
-  }
-  return true;
-}
-
-async function askPermission() {
-  // The API recently changed from taking a callback to returning a Promise. The
-  // problem with this, is that we can't tell what version of the API is
-  // implemented by the current browser, so you have to implement both and handle both.
-  const permission = await new Promise<NotificationPermission>((resolve, reject) => {
-    const permissionResult = Notification.requestPermission(function (result) {
-      resolve(result);
-    });
-
-    if (permissionResult) {
-      permissionResult.then(resolve, reject);
-    }
-  });
-  if (permission === 'granted') {
-    permissionGranted.value = true;
-  }
-  return permission;
-}
-
-function urlBase64ToUint8Array(s:string) {
-  const padding = '='.repeat((4 - s.length % 4) % 4);
-  const base64 = (s + padding)
-      .replace(/\-/g, '+')
-      .replace(/_/g, '/');
-
-  const rawData = atob(base64);
-  const outputArray = new Uint8Array(rawData.length);
-
-  for (let i = 0; i < rawData.length; ++i) {
-      outputArray[i] = rawData.charCodeAt(i);
-  }
-  return outputArray;
-}
-
-async function subscribeUserToPush() {
-  if (!$pwa.isRegistered || !$pwa.registration.value) {
-    throw new Error('service worker not registered');
-  }
-
-  const subscribeOptions = {
-    userVisibleOnly: true,
-    applicationServerKey: urlBase64ToUint8Array(String(vapidPublicKey)),
-  };
-
-  return $pwa.registration.value.pushManager.subscribe(subscribeOptions);
-}
-
-async function saveSubscription(sub:PushSubscription) {
-  await $fetch('/api/subscriptions', {
-    method: 'POST',
-    body: {
-      details: sub
-    }
-  });
-}
-
-async function deleteSubscription(sub:PushSubscription) {
-  return $fetch('/api/subscriptions', {
-    method: 'DELETE',
-    query: {
-      endpoint: sub.endpoint
-    }
-  });
-}
-
-async function toggleNotifications() {
-  if (currentSubscription.value) {
-    await tearDownNotifications();
-  } else {
-    await setupNotifications();
-  }
-}
-
-async function setupNotifications() {
-  loading.value = true;
-  await askPermission();
-  try {
-    const pushSubscription = await subscribeUserToPush();
-    await saveSubscription(pushSubscription);
-    currentSubscription.value = pushSubscription;
-    toast.add({
-      color: 'success',
-      title: 'Notification enabled',
-      description: 'Notifications are enabled for this device/browser.'
-    });
-  } catch (err:any) {
-    toast.add({
-      color: 'error',
-      title: 'Error disabling notifications',
-      description: err.message
-    });
-  } finally {
-    loading.value = false;
-  }
-}
-
-async function tearDownNotifications() {
-  if (currentSubscription.value) {
-    await Promise.allSettled([
-      await currentSubscription.value?.unsubscribe(),
-      await deleteSubscription(currentSubscription.value),
-    ]);
-    currentSubscription.value = null;
-    toast.add({
-      color: 'success',
-      title: 'Notification disabled',
-      description: 'Notifications are disabled for this device/browser.'
-    });
-  }
-}
-
-async function checkForCurrentSubscription() {
-  if ($pwa.isRegistered) {
-    try {
-      return $pwa.registration.value?.pushManager.getSubscription() ?? null;
-    } catch (err:any) {
-      console.warn('error retrieving current subscriptions', err);
-    }
-  }
-  return null;
-}
-
-onMounted(async () => {
-  currentSubscription.value = await checkForCurrentSubscription();
-});
+const {
+  loading,
+  supported,
+  permissionGranted,
+  tooltipText,
+  bellIcon,
+  toggle,
+} = useNotifications();
 </script>

--- a/app/composable/useMobileNav.ts
+++ b/app/composable/useMobileNav.ts
@@ -1,0 +1,86 @@
+import type { DropdownMenuItem, NavigationMenuItem } from '@nuxt/ui';
+import { useNotifications } from '~/composable/useNotifications';
+
+// Shared state for the mobile bottom tab bar, consumed by both layouts
+// (`app/layouts/default.vue` and `app/layouts/full-screen.vue`). Extracted because
+// the bar is driven by `UNavigationMenu` `children`/`onSelect` (no nested
+// interactive elements), so the old "edit in place, don't share" rationale no
+// longer applies. The only per-layout difference is the SSR placeholder item set,
+// which each layout keeps locally and passes to the bar's `#placeholder` branch.
+export function useMobileNav() {
+  const { clear, user } = useUserSession();
+  const { supported, subscribed, ready, bellIcon, toggle, disableNotifications } = useNotifications();
+
+  async function logout() {
+    try {
+      await disableNotifications();
+    } catch (err) {
+      console.debug('error disabling notifications during logout', err);
+    }
+
+    await clear();
+    return navigateTo('/sign-in');
+  }
+
+  const authedDropdown = computed<DropdownMenuItem[]>(() => {
+    const isAdmin = user.value ? user.value.roles.includes('Admin') : false;
+    return [
+      { label: 'Invite', icon: 'i-heroicons-envelope-open', to: '/invite', disabled: !isAdmin },
+      { label: 'Settings', icon: 'i-heroicons-adjustments-horizontal', to: '/settings', disabled: !isAdmin },
+      { label: 'Logout', icon: 'i-heroicons-arrow-right-start-on-rectangle', onSelect: () => { logout().catch((e) => console.error(e)); } },
+    ];
+  });
+
+  // One UNavigationMenu owns the whole bar so every tab is sized and aligned by the
+  // framework. `item: flex-1` makes the four tabs equal width; the link is stacked
+  // icon-over-label and centered. Alerts toggles push via onSelect; Menu opens its
+  // items as a native submenu (children).
+  const barUi = {
+    root: 'py-0 [&>div]:w-full',
+    list: 'w-full',
+    item: 'flex-1 py-0',
+    link: 'w-full flex-col items-center justify-center gap-1 px-1',
+    linkLeadingIcon: 'size-5',
+    linkLabel: 'text-[10px]/3 font-normal text-center',
+    linkTrailingIcon: 'hidden',
+    // The submenu (Menu tab's children) otherwise opens below the trigger, which is
+    // off-screen for a bottom bar — flip its viewport above the bar.
+    viewportWrapper: 'top-auto bottom-full',
+    childList: 'grid-cols-1',
+    childLink: 'justify-center',
+  };
+
+  const authedBarItems = computed<NavigationMenuItem[]>(() => [
+    { label: user.value?.userName || 'Home', icon: 'i-heroicons-home', to: '/', exact: true },
+    { label: 'Reports', icon: 'i-heroicons-document-magnifying-glass', to: '/reports' },
+    {
+      label: 'Alerts',
+      icon: bellIcon.value,
+      // Always render the Alerts tab so the bar never reflows. It stays disabled
+      // until the async support/subscription check resolves — and on browsers
+      // without push support, where tapping would throw on
+      // `Notification.requestPermission` — mirroring the desktop bell's disabled
+      // fallback. Once `ready` (and supported) it enables and shows the real state.
+      disabled: !ready.value || !supported.value,
+      // Expose the on/off state to assistive tech — the icon swap is invisible to
+      // screen readers. `aria-label` is forwarded by `pickLinkProps` (it picks
+      // `aria-*` keys), so this reaches the rendered link element.
+      'aria-label': subscribed.value ? 'Alerts, notifications on' : 'Alerts, notifications off',
+      onSelect: () => { toggle().catch((e) => console.error(e)); },
+    },
+    { label: 'Menu', icon: 'i-heroicons-bars-3', children: authedDropdown.value },
+  ]);
+
+  const loggedOutBarItems: NavigationMenuItem[] = [
+    { label: 'Reports', icon: 'i-heroicons-document', to: '/' },
+    { label: 'Sign In', icon: 'i-heroicons-arrow-right-end-on-rectangle', to: '/sign-in' },
+  ];
+
+  return {
+    barUi,
+    authedDropdown,
+    authedBarItems,
+    loggedOutBarItems,
+    user,
+  };
+}

--- a/app/composable/useNotifications.ts
+++ b/app/composable/useNotifications.ts
@@ -1,0 +1,210 @@
+// Push-notification subscription state + actions, shared by the desktop bell
+// (components/notifications.vue) and the mobile bottom tab bar
+// (composable/useMobileNav.ts, consumed by both layouts).
+
+export function useNotifications() {
+  const { public: { vapidPublicKey } } = useRuntimeConfig();
+  const { $pwa } = useNuxtApp();
+  const toast = useToast();
+
+  const loading = useState<boolean>('notifications:loading', () => false);
+  const supported = useState<boolean>('notifications:supported', () => false);
+  const permissionGranted = useState<boolean>('notifications:permissionGranted', () => true);
+  const subscribed = useState<boolean>('notifications:subscribed', () => false);
+  // False until the initial support/permission/subscription check finishes in
+  // onMounted, so consumers can show a disabled control while checking instead of
+  // hiding it (hiding would reflow the mobile tab bar when the check resolves).
+  const ready = useState<boolean>('notifications:ready', () => false);
+
+  const tooltipText = computed(() => {
+    if (!permissionGranted.value) return 'Enable new report notifications';
+    return subscribed.value ? 'Notifications enabled' : 'Notifications disabled';
+  });
+
+  const bellIcon = computed(() => {
+    if (!permissionGranted.value) return 'i-heroicons-bell-slash';
+    return subscribed.value ? 'i-heroicons-bell' : 'i-heroicons-bell-snooze';
+  });
+
+  function isSupported() {
+    try {
+      if (!('serviceWorker' in navigator)) {
+        return false;
+      }
+
+      if (!('PushManager' in window)) {
+        return false;
+      }
+
+      if (!('Notification' in window)) {
+        return false;
+      }
+    } catch (err: any) {
+      return false;
+    }
+    return true;
+  }
+
+  async function askPermission() {
+    // The API recently changed from taking a callback to returning a Promise. The
+    // problem with this, is that we can't tell what version of the API is
+    // implemented by the current browser, so you have to implement both and handle both.
+    const permission = await new Promise<NotificationPermission>((resolve, reject) => {
+      const permissionResult = Notification.requestPermission(function (result) {
+        resolve(result);
+      });
+
+      if (permissionResult) {
+        permissionResult.then(resolve, reject);
+      }
+    });
+    if (permission === 'granted') {
+      permissionGranted.value = true;
+    } else if (permission === 'denied') {
+      permissionGranted.value = false;
+    }
+    return permission;
+  }
+
+  function urlBase64ToUint8Array(s: string) {
+    const padding = '='.repeat((4 - s.length % 4) % 4);
+    const base64 = (s + padding)
+      .replace(/\-/g, '+')
+      .replace(/_/g, '/');
+
+    const rawData = atob(base64);
+    const outputArray = new Uint8Array(rawData.length);
+
+    for (let i = 0; i < rawData.length; ++i) {
+      outputArray[i] = rawData.charCodeAt(i);
+    }
+    return outputArray;
+  }
+
+  async function subscribeUserToPush() {
+    if (!$pwa.isRegistered || !$pwa.registration.value) {
+      throw new Error('service worker not registered');
+    }
+
+    const subscribeOptions = {
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(String(vapidPublicKey)),
+    };
+
+    return $pwa.registration.value.pushManager.subscribe(subscribeOptions);
+  }
+
+  async function saveSubscription(sub: PushSubscription) {
+    await $fetch('/api/subscriptions', {
+      method: 'POST',
+      body: {
+        details: sub
+      }
+    });
+  }
+
+  async function deleteSubscription(sub: PushSubscription) {
+    return $fetch('/api/subscriptions', {
+      method: 'DELETE',
+      query: {
+        endpoint: sub.endpoint
+      }
+    });
+  }
+
+  async function checkForCurrentSubscription(): Promise<PushSubscription | null> {
+    if ($pwa.isRegistered) {
+      try {
+        return $pwa.registration.value?.pushManager.getSubscription() ?? null;
+      } catch (err: any) {
+        console.warn('error retrieving current subscriptions', err);
+      }
+    }
+    return null;
+  }
+
+  async function setupNotifications() {
+    loading.value = true;
+    await askPermission();
+    try {
+      const pushSubscription = await subscribeUserToPush();
+      await saveSubscription(pushSubscription);
+      subscribed.value = true;
+      toast.add({
+        color: 'success',
+        title: 'Notification enabled',
+        description: 'Notifications are enabled for this device/browser.'
+      });
+    } catch (err: any) {
+      toast.add({
+        color: 'error',
+        title: 'Error enabling notifications',
+        description: err.message
+      });
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function tearDownNotifications(sub: PushSubscription, { notify = true } = {}) {
+    await Promise.allSettled([
+      sub.unsubscribe(),
+      deleteSubscription(sub),
+    ]);
+    subscribed.value = false;
+    if (notify) {
+      toast.add({
+        color: 'success',
+        title: 'Notification disabled',
+        description: 'Notifications are disabled for this device/browser.'
+      });
+    }
+  }
+
+  async function toggleNotifications() {
+    const sub = await checkForCurrentSubscription();
+    if (sub) {
+      await tearDownNotifications(sub);
+    } else {
+      await setupNotifications();
+    }
+  }
+
+  // Toggle for a single control (desktop bell + mobile Alerts tab): enable if
+  // permission has not been granted yet, otherwise flip the subscription.
+  function toggle() {
+    return permissionGranted.value ? toggleNotifications() : setupNotifications();
+  }
+
+  // Re-fetch and tear down the current subscription (used by logout). Resets the
+  // shared `subscribed` flag so every bell reflects the disabled state after the
+  // session is cleared. Silent: the user is being redirected to sign-in, so a
+  // "Notification disabled" toast would appear there and read as unrelated.
+  async function disableNotifications() {
+    const sub = await checkForCurrentSubscription();
+    if (sub) {
+      await tearDownNotifications(sub, { notify: false });
+    }
+  }
+
+  onMounted(async () => {
+    supported.value = isSupported();
+    permissionGranted.value = Notification.permission !== 'denied';
+    subscribed.value = !!(await checkForCurrentSubscription());
+    ready.value = true;
+  });
+
+  return {
+    loading,
+    supported,
+    permissionGranted,
+    subscribed,
+    ready,
+    tooltipText,
+    bellIcon,
+    toggle,
+    toggleNotifications,
+    setupNotifications,
+    disableNotifications,
+  };
+}

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -1,7 +1,7 @@
 <!-- The style classes and exactActiveClass on links is because nuxt-ui <ULink> prefetch is broken -->
 <template>
-  <UContainer>
-    <header>
+  <UContainer class="pb-[calc(4rem+env(safe-area-inset-bottom))] lg:pb-0">
+    <header class="hidden lg:block">
       <AuthState>
           <template #default="{ loggedIn }">
             <div v-if="loggedIn" class="flex">
@@ -15,17 +15,9 @@
                     <li><UButton color="neutral" class="m-2" icon="i-heroicons-bell-slash" disabled /></li>
                   </template>
                 </ClientOnly>
-                <UPopover v-model:open="navOpen" :content="{ side: 'bottom', align: 'end' }">
+                <UDropdownMenu :items="authedDropdown" :content="{ side: 'bottom', align: 'end' }">
                   <UButton color="neutral" variant="outline" icon="i-heroicons-bars-3" class="m-2" />
-                  <template #content>
-                    <ul class="p-1 bg-white  dark:bg-neutral-800  min-w-44">
-                      <li v-for="link in authedDropdown" class="flex w-full items-center flex-row-reverse mb-1 last:mb-0">
-                        <UButton v-if="link.click" @click="() => { navOpen = false; link.click?.(); }" variant="ghost" color="neutral" class="w-full justify-between dark:hover:bg-neutral-900"><UIcon :name="link.icon" class="ml-2"/><span>{{ link.label }}</span></UButton>
-                        <NuxtLink v-else-if="!link.disabled" class="flex px-2 py-1 w-full rounded-md justify-between items-center hover:bg-neutral-50 dark:hover:bg-neutral-900" active-class="bg-neutral-50 dark:bg-neutral-900" :to="link.to" @click="navOpen = false"><UIcon :name="link.icon" class="ml-2"/><span>{{ link.label }}</span></NuxtLink>
-                      </li>
-                    </ul>
-                  </template>
-                </UPopover>
+                </UDropdownMenu>
               </ul>
             </div>
             <ul v-else class="w-full flex items-center justify-end border-b border-default">
@@ -45,74 +37,27 @@
     <footer>
       <div class="py-2"></div>
     </footer>
+    <!-- Mobile bottom tab bar -->
+    <nav aria-label="Primary" class="fixed bottom-0 inset-x-0 z-30 lg:hidden border-t border-default bg-default pb-[env(safe-area-inset-bottom)]">
+      <AuthState>
+        <template #default="{ loggedIn }">
+          <UNavigationMenu :items="loggedIn ? authedBarItems : loggedOutBarItems" class="w-full" :ui="barUi" />
+        </template>
+        <template #placeholder>
+          <UNavigationMenu :items="placeholderBarItems" class="w-full" :ui="barUi" />
+        </template>
+      </AuthState>
+    </nav>
   </UContainer>
 </template>
 
 <script lang="ts" setup>
-import { computed } from 'vue';
+import type { NavigationMenuItem } from '@nuxt/ui';
+import { useMobileNav } from '~/composable/useMobileNav';
 
-const { clear, user } = useUserSession();
-const { $pwa } = useNuxtApp();
+const { barUi, authedDropdown, authedBarItems, loggedOutBarItems, user } = useMobileNav();
 
-// Controls the nav dropdown popover so items can close it on click (v3 Popover's
-// #content slot no longer exposes a `close` helper).
-const navOpen = ref(false);
-
-async function deleteSubscription(sub:PushSubscription) {
-  return $fetch('/api/subscriptions', {
-    method: 'DELETE',
-    query: {
-      endpoint: sub.endpoint
-    }
-  });
-}
-
-async function getCurrentSubscription():Promise<PushSubscription|null> {
-  const registration = $pwa.registration;
-  if (!registration.value) {
-    throw new Error('service worker not registered');
-  }
-  return registration.value?.pushManager.getSubscription() ?? null;
-}
-
-async function disableNotifications() {
-  const subscriptions = await getCurrentSubscription();
-  if (subscriptions) {
-    await Promise.allSettled([
-      subscriptions.unsubscribe(),
-      deleteSubscription(subscriptions),
-    ]);
-  }
-}
-
-async function logout() {
-  try {
-    await disableNotifications();
-  } catch (err) {
-    console.debug('error disabling notifications during logout', err);
-  }
-
-  await clear();
-  return navigateTo('/sign-in');
-}
-
-const authedDropdown = computed(() => {
-  return [
-    {
-      label: 'Invite',
-      icon: 'i-heroicons-envelope-open',
-      to: '/invite',
-      disabled: user.value ? !user.value.roles.includes('Admin') : true,
-    }, {
-      label: 'Settings',
-      icon: 'i-heroicons-adjustments-horizontal',
-      to: '/settings',
-      disabled: user.value ? !user.value.roles.includes('Admin') : true,
-    }, {
-      label: `Logout`,
-      icon: 'i-heroicons-arrow-right-start-on-rectangle',
-      click: logout
-    }
-  ];
-});
+// SSR placeholder for the mobile bar — mirrors this layout's logged-out desktop
+// placeholder. The bar's authed/logged-out items come from useMobileNav.
+const placeholderBarItems: NavigationMenuItem[] = loggedOutBarItems;
 </script>

--- a/app/layouts/full-screen.vue
+++ b/app/layouts/full-screen.vue
@@ -1,6 +1,6 @@
 <!-- The style classes and exactActiveClass on links is because nuxt-ui <ULink> prefetch is broken -->
 <template>
-  <header>
+  <header class="hidden lg:block">
     <AuthState>
       <template #default="{ loggedIn }">
         <div v-if="loggedIn" class="w-full border-b border-default">
@@ -31,24 +31,9 @@
                   </li>
                 </template>
               </ClientOnly>
-              <UPopover v-model:open="navOpen" :content="{ side: 'bottom', align: 'end' }">
+              <UDropdownMenu :items="authedDropdown" :content="{ side: 'bottom', align: 'end' }">
                 <UButton color="neutral" variant="outline" icon="i-heroicons-bars-3" class="m-2" />
-                <template #content>
-                  <ul class="p-1 bg-white  dark:bg-neutral-800  min-w-44">
-                    <li v-for="link in authedDropdown" class="flex w-full items-center flex-row-reverse mb-1 last:mb-0">
-                      <UButton v-if="link.click" @click="() => { navOpen = false; link.click?.(); }" variant="ghost"
-                        color="neutral" class="w-full justify-between dark:hover:bg-neutral-900">
-                        <UIcon :name="link.icon" class="ml-2" /><span>{{ link.label }}</span>
-                      </UButton>
-                      <NuxtLink v-else
-                        class="flex px-2 py-1 w-full rounded-md justify-between items-center hover:bg-neutral-50 dark:hover:bg-neutral-900"
-                        active-class="bg-neutral-50 dark:bg-neutral-900" :to="link.to" @click="navOpen = false">
-                        <UIcon :name="link.icon" class="ml-2" /><span>{{ link.label }}</span>
-                      </NuxtLink>
-                    </li>
-                  </ul>
-                </template>
-              </UPopover>
+              </UDropdownMenu>
             </ul>
           </UContainer>
         </div>
@@ -105,6 +90,17 @@
     </AuthState>
   </header>
   <slot />
+  <!-- Mobile bottom tab bar -->
+  <nav aria-label="Primary" class="fixed bottom-0 inset-x-0 z-30 lg:hidden border-t border-default bg-default pb-[env(safe-area-inset-bottom)]">
+    <AuthState>
+      <template #default="{ loggedIn }">
+        <UNavigationMenu :items="loggedIn ? authedBarItems : loggedOutBarItems" class="w-full" :ui="barUi" />
+      </template>
+      <template #placeholder>
+        <UNavigationMenu :items="placeholderBarItems" class="w-full" :ui="barUi" />
+      </template>
+    </AuthState>
+  </nav>
 </template>
 
 <style>
@@ -115,14 +111,10 @@
 </style>
 
 <script lang="ts" setup>
-import { computed } from 'vue';
+import type { NavigationMenuItem } from '@nuxt/ui';
+import { useMobileNav } from '~/composable/useMobileNav';
 
-const { clear, user } = useUserSession();
-const { $pwa } = useNuxtApp();
-
-// Controls the nav dropdown popover so items can close it on click (v3 Popover's
-// #content slot no longer exposes a `close` helper).
-const navOpen = ref(false);
+const { barUi, authedDropdown, authedBarItems, loggedOutBarItems, user } = useMobileNav();
 
 // is this really the best way to do this?!
 useHead({
@@ -134,61 +126,11 @@ useHead({
   }
 });
 
-async function deleteSubscription(sub: PushSubscription) {
-  return $fetch('/api/subscriptions', {
-    method: 'DELETE',
-    query: {
-      endpoint: sub.endpoint
-    }
-  });
-}
-
-async function getCurrentSubscription(): Promise<PushSubscription | null> {
-  const registration = $pwa.registration;
-  if (!registration.value) {
-    throw new Error('service worker not registered');
-  }
-  return registration.value?.pushManager.getSubscription() ?? null;
-}
-
-async function disableNotifications() {
-  const subscriptions = await getCurrentSubscription();
-  if (subscriptions) {
-    await Promise.allSettled([
-      subscriptions.unsubscribe(),
-      deleteSubscription(subscriptions),
-    ]);
-  }
-}
-
-async function logout() {
-  try {
-    await disableNotifications();
-  } catch (err) {
-    console.debug('error disabling notifications during logout', err);
-  }
-
-  await clear();
-  return navigateTo('/sign-in');
-}
-
-const authedDropdown = computed(() => {
-  return [
-    {
-      label: 'Invite',
-      icon: 'i-heroicons-envelope-open',
-      to: '/invite',
-      disabled: user.value ? !user.value.roles.includes('Admin') : true,
-    }, {
-      label: 'Settings',
-      icon: 'i-heroicons-adjustments-horizontal',
-      to: '/settings',
-      disabled: user.value ? !user.value.roles.includes('Admin') : true,
-    }, {
-      label: `Logout`,
-      icon: 'i-heroicons-arrow-right-start-on-rectangle',
-      click: logout
-    }
-  ];
-});
+// SSR placeholder for the mobile bar — mirrors this layout's desktop placeholder,
+// which also includes a Report link.
+const placeholderBarItems: NavigationMenuItem[] = [
+  { label: 'Reports', icon: 'i-heroicons-document', to: '/' },
+  { label: 'Report', icon: 'i-heroicons-document-plus', to: '/report' },
+  { label: 'Sign In', icon: 'i-heroicons-arrow-right-end-on-rectangle', to: '/sign-in' },
+];
 </script>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -59,9 +59,9 @@
         class="flex lg:hidden flex-col items-center h-lvh overflow-y-scroll overscroll-y-contain z-10 snap-y snap-mandatory scrollbar-none"
       >
         <div class="basis-[calc(35dvh)] grow-0 shrink-0 snap-start"></div>
-        <div class="basis-[calc(50dvh)] grow-0 shrink-0 snap-start"></div>
+        <div class="basis-[calc(45dvh)] grow-0 shrink-0 snap-start"></div>
         <div
-          class="relative w-full bg-neutral-100 dark:bg-neutral-900 z-20 p-4 pb-48 shadow-[0px_0px_25px_-10px_rgba(0,0,0,0.75)] rounded-t-xl before:w-8 before:h-1 before:bg-neutral-200 before:dark:bg-neutral-100 before:rounded before:mx-auto before:block before:-mt-2"
+          class="relative w-full bg-neutral-100 dark:bg-neutral-900 z-20 p-4 pb-[calc(12rem+env(safe-area-inset-bottom))] shadow-[0px_0px_25px_-10px_rgba(0,0,0,0.75)] rounded-t-xl before:w-8 before:h-1 before:bg-neutral-200 before:dark:bg-neutral-100 before:rounded before:mx-auto before:block before:-mt-2"
         >
           <UButton
             class="shadow-lg absolute -top-16 right-8 lg:hidden"
@@ -110,7 +110,6 @@ import {
   type ReportPostSchema,
 } from "~/components/report-form.vue";
 import type { MapOptions, SelectIntegration, Prettify } from "../../db/schema";
-import { formatDistanceToNow } from "date-fns";
 import { useReportSubmit } from "~/composable/reportSubmit";
 import getDateMinusNHours from "#shared/utils/get-date-minus-n-hours";
 

--- a/server/api/reports/index.post.ts
+++ b/server/api/reports/index.post.ts
@@ -1,6 +1,6 @@
 import { reportInsertSchema } from "../../../db/schema";
 import { createReports } from "../../../shared/utils/abilities";
-import CreateReport from "#shared/utils/create-report";
+import CreateReport from "../../utils/create-report";
 
 export default defineEventHandler(async (event) => {
   // @ts-ignore TODO https://github.com/nuxt/nuxt/issues/29263

--- a/server/api/subscriptions/[id].delete.ts
+++ b/server/api/subscriptions/[id].delete.ts
@@ -10,8 +10,15 @@ const deleteSubscriptionParamsSchema = z.object({
 
 export default defineEventHandler(async (event) => {
   const { id } = await getValidatedRouterParams(event, deleteSubscriptionParamsSchema.parse);
+
+  // Look up the subscription's owner here (the ability no longer touches the DB).
+  const sub = await db.query.subscriptions.findFirst({
+    columns: { userId: true },
+    where: eq(subscriptionsTable.id, id),
+  });
+
   // @ts-ignore TODO https://github.com/nuxt/nuxt/issues/29263
-  await authorize(event, deleteSubscription, id);
+  await authorize(event, deleteSubscription, sub?.userId ?? null);
 
   try {
     await db.delete(subscriptionsTable).where(eq(subscriptionsTable.id, id));

--- a/server/api/subscriptions/index.delete.ts
+++ b/server/api/subscriptions/index.delete.ts
@@ -31,7 +31,7 @@ export default defineEventHandler(async (event) => {
   }
 
   // @ts-ignore TODO https://github.com/nuxt/nuxt/issues/29263
-  await authorize(event, deleteSubscription, userSub.subscriptions.id);
+  await authorize(event, deleteSubscription, userSub.subscriptions.userId);
   try {
     await db.update(subscriptionsTable).set({deletedAt: new Date()}).where(eq(subscriptionsTable.id, userSub.subscriptions.id));
     setResponseStatus(event, 200, "Deleted");

--- a/server/cron/masto-poller.ts
+++ b/server/cron/masto-poller.ts
@@ -6,7 +6,7 @@ import { eq, desc } from 'drizzle-orm';
 import unfareLogger from '../../shared/utils/unfareLogger';
 import { URL } from 'node:url';
 import sanitizeHtml from 'sanitize-html';
-import CreateReport from "#shared/utils/create-report";
+import CreateReport from "../utils/create-report";
 
 async function getLatestMentionId(): Promise<string|null> {
   const reportsUris = await db.select({uri: reports.uri}).from(reports).where(eq(reports.source, 'mastodon')).orderBy(desc(reports.createdAt)).limit(1);

--- a/server/utils/create-report.ts
+++ b/server/utils/create-report.ts
@@ -1,4 +1,4 @@
-import { DB as db } from "../../server/sqlite-service"
+import { DB as db } from "../sqlite-service"
 import { reports as reportsTable, type InsertReport, type SelectReport } from "../../db/schema";
 import Notify from "./notify";
 import type { H3Event, EventHandlerRequest } from 'h3';

--- a/server/utils/notify.test.ts
+++ b/server/utils/notify.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { formatReportAsNotification } from './notify';
-import getPlainTextSummary from './get-plain-text-summary';
+import getPlainTextSummary from '#shared/utils/get-plain-text-summary';
 import type { SelectReport } from '../../db/schema';
 
 const report = {

--- a/server/utils/notify.ts
+++ b/server/utils/notify.ts
@@ -1,4 +1,4 @@
-import { DB as db } from "../../server/sqlite-service"
+import { DB as db } from "../sqlite-service"
 import {
   users as usersTable,
   subscriptions as subscriptionsTable,

--- a/shared/utils/abilities.ts
+++ b/shared/utils/abilities.ts
@@ -1,6 +1,4 @@
-import { users, subscriptions } from '../../db/schema';
-import { DB as db } from "../../server/sqlite-service";
-import { eq } from 'drizzle-orm';
+import { users } from '../../db/schema';
 
 type User = typeof users.$inferSelect;
 
@@ -44,14 +42,10 @@ export const getPublicIntegrations = defineAbility({ allowGuest: true }, (user: 
 
 // user subscription abilities
 export const createSubscription = defineAbility(() => true);
-export const deleteSubscription = defineAbility(async (user: User, targetSubscriptionId: number) => {
-  const sub = await db.query.subscriptions.findFirst({
-    columns: {
-      userId: true
-    },
-    where: eq(subscriptions.id, targetSubscriptionId)
-  });
-
-  if (sub === undefined) return false;
-  return user.id === sub.userId;
+export const deleteSubscription = defineAbility((user: User, subscriptionUserId: number | null) => {
+  // Ownership check. The subscription's owner is looked up in the route handler
+  // (server/api/subscriptions/*.delete.ts) and passed in, so this shared ability
+  // stays free of the server-only DB (shared/ must not import Nitro code).
+  if (subscriptionUserId === null) return false;
+  return user.id === subscriptionUserId;
 });


### PR DESCRIPTION
## Mobile menu refactor

Closes #220.

On mobile, the top navigation moves to a fixed bottom tab bar (the common native-app pattern); desktop keeps the existing top nav.

### Changes
- **Fixed mobile bottom tab bar** built on Nuxt UI's `UNavigationMenu` (bottom-tab-bar variant). One `UNavigationMenu` owns all tabs so the framework sizes and aligns them uniformly (equal-width, icon-over-label). Shown only on mobile (`lg:hidden`); the top nav is `hidden lg:block`.
  - Logged in: **Home · Reports · Alerts · Menu**. Logged out: **Reports · Sign In**.
  - **Alerts** toggles push notifications via the tab's `onSelect`.
  - **Menu** opens a native submenu (Invite / Settings / Logout) flipped **upward** above the bar, with its rows centered.
- **Hamburger menu → `UDropdownMenu`** on desktop (opens down); replaces the old `UPopover`.
- **`useNotifications()` composable** — push-subscription state/logic extracted out of `notifications.vue` and shared by the desktop bell and the mobile bar (SSR-safe; browser APIs read in `onMounted`).
- **Recent Sightings drawer** (root page) retuned so it rests above the bar and is more compact by default; default-layout pages get bottom clearance so the fixed bar never covers their content.
- Mobile `<nav>` gets an `aria-label`.

### Verification
- `npm run typecheck` green; `npm run test` 40/40.
- Manually verified in a mobile viewport: four equal, aligned tabs; the Menu submenu opens upward on-screen with a working Logout; the logged-out bar is even; the sightings drawer clears the bar; desktop keeps its top nav (no bottom bar).
