### PR TITLE
Improve SQLite DB ops: consistent backups + pragma tuning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:${NODE_VERSION}-slim AS base
 ARG PORT=3000
 ARG TARGETARCH
 WORKDIR /src
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update && apt-get install -y curl sqlite3
 RUN curl https://dl.min.io/client/mc/release/linux-${TARGETARCH}/mc --create-dirs -o /usr/local/bin/mc
 RUN chmod +x /usr/local/bin/mc
 

--- a/backup.sh
+++ b/backup.sh
@@ -10,18 +10,63 @@ fi
 if [[ "${1-}" =~ ^-*h(elp)?$ ]]; then
     echo 'Usage: ./backup.sh
 
-This script backsup UnfareSF DBs to MinIO bucket.
+This script backs up UnfareSF SQLite DBs to a MinIO bucket.
+
+Instead of copying the live database files directly (which can produce a
+torn/corrupt backup, since the app writes them in WAL mode), it first
+takes a consistent snapshot of every *.db file with SQLite`s VACUUM INTO.
+VACUUM INTO runs inside a single read transaction, so it never blocks the
+app from reading or writing, and it emits a single clean file with no
+-wal/-shm sidecars. The snapshots are then uploaded to MinIO.
+
+Environment:
+  DBS_DIR             Directory holding the live *.db files (default: /app/dbs)
+  BACKUP_STAGING_DIR  Base directory under which a fresh, unique staging dir is
+                      created (and auto-removed on exit). Point this at a volume
+                      with free space >= the largest DB (the GTFS DB is ~1GB).
+                      Defaults to TMPDIR or /tmp.
+  MINIO_BACKUPS_ACCESS_KEY / MINIO_BACKUPS_SECRET_KEY  MinIO credentials.
 '
   exit
 fi
 
 cd "$(dirname "$0")"
 
+DBS_DIR="${DBS_DIR:-/app/dbs}"
+
+# Always stage snapshots in a fresh unique dir that WE create, and remove only
+# that dir on exit. If BACKUP_STAGING_DIR is set it is used as the *base* the
+# unique dir is created under -- so cleanup can never rm a caller-supplied dir
+# (or the DBs) even if BACKUP_STAGING_DIR points at DBS_DIR.
+STAGING_BASE="${BACKUP_STAGING_DIR:-${TMPDIR:-/tmp}}"
+mkdir -p "$STAGING_BASE"
+STAGING="$(mktemp -d -p "$STAGING_BASE" unfaresf-backup.XXXXXX)"
+trap 'rm -rf "$STAGING"' EXIT
+
 main() {
+  # Take a consistent, non-blocking snapshot of each SQLite DB.
+  # VACUUM INTO reads the source in one read transaction (safe against a live,
+  # WAL-mode DB) and writes a single clean file -- no -wal/-shm sidecars.
+  # Snapshots land outside DBS_DIR, so they are never re-read as source DBs.
+  local db count=0
+  for db in "$DBS_DIR"/*.db; do
+    [[ -e "$db" ]] || continue   # no matches -> glob stays literal; skip it
+    echo "Snapshotting $(basename "$db")..."
+    sqlite3 "$db" "VACUUM INTO '$STAGING/$(basename "$db")'"
+    count=$((count + 1))
+  done
+
+  if [[ "$count" -eq 0 ]]; then
+    echo "No *.db files found in $DBS_DIR; nothing to back up." >&2
+    exit 1
+  fi
+
   set +o history
   mc alias set spring-lake https://minio.unfaresf.org "${MINIO_BACKUPS_ACCESS_KEY-}" "${MINIO_BACKUPS_SECRET_KEY-}";
   set -o history
-  mc cp --recursive /app/dbs/ spring-lake/backups/unfaresf/dbs/;
+
+  echo "Uploading $count snapshot(s) to MinIO..."
+  mc cp --recursive "$STAGING/" spring-lake/backups/unfaresf/dbs/;
 }
 
 main "$@"

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -23,6 +23,7 @@ nixPkgs = [
     'npm-11_x',
     'openssl',
     'minio-client',
+    'sqlite',
 ]
 nixLibs = [
     'gcc-unwrapped',

--- a/server/sqlite-service.ts
+++ b/server/sqlite-service.ts
@@ -6,10 +6,18 @@ const config = useRuntimeConfig();
 
 const sqlite = new Database(config.dbFileName!);
 sqlite.pragma('journal_mode = WAL');
+// foreign_keys is a per-connection pragma; set it explicitly so onDelete
+// cascades in the schema are enforced regardless of the driver/build defaults.
+sqlite.pragma('foreign_keys = ON');
 const DB = drizzle({ schema: appSchema, client: sqlite });
 
 const gtfsSqlite = new Database(config.gtfsDbFilePath!);
 gtfsSqlite.pragma('journal_mode = WAL');
+gtfsSqlite.pragma('foreign_keys = ON');
+// The GTFS DB is large (~1GB) and read-heavy; give it a bigger page cache and
+// memory-mapped reads to cut query latency.
+gtfsSqlite.pragma('cache_size = -65536');   // 64 MiB page cache (negative value = KiB)
+gtfsSqlite.pragma('mmap_size = 268435456'); // 256 MiB memory-mapped I/O
 const gtfsDB = drizzle({ client: gtfsSqlite });
 
 export { DB, gtfsDB };


### PR DESCRIPTION
## Summary

Improves reliability and performance of the SQLite database operations.

### 1. Consistent, non-blocking backups (`backup.sh`)
The old backup did a raw `mc cp` of the live `*.db` files. Because the app writes them in **WAL mode**, that copy could be torn/corrupt or stale (recent transactions may live only in the `-wal` file), and it also uploaded `-wal`/`-shm`/`.DS_Store` noise.

Now the script takes a consistent snapshot of each `*.db` with `sqlite3 VACUUM INTO` first, then uploads only the snapshots:
- `VACUUM INTO` runs in a single read transaction — **never blocks the app's readers or writers**, and emits a single clean file with no sidecars.
- Snapshots stage in a fresh unique dir (auto-removed on exit; only that dir is ever removed, never a caller-supplied path), overridable via `BACKUP_STAGING_DIR`.
- Added a zero-DB guard and clearer logging.

### 2. Install `sqlite3` CLI in deploy images
`backup.sh` now shells out to `sqlite3`, so it's added to both build targets (`Dockerfile` via apt, `nixpacks.toml` via nixPkgs).

### 3. SQLite pragma tuning (`server/sqlite-service.ts`)
- **`foreign_keys = ON`** set explicitly on both connections so the schema's `onDelete: cascade` is enforced regardless of driver/build defaults (it's a per-connection pragma).
- **GTFS read tuning**: the large (~1GB), read-heavy GTFS DB gets a bigger page cache (`cache_size = -65536`, 64 MiB) and memory-mapped reads (`mmap_size = 256 MiB`) to cut query latency.

> Note: `synchronous=NORMAL` was investigated but **not** changed — the app is already effectively at NORMAL because better-sqlite3 compiles `DEFAULT_WAL_SYNCHRONOUS=1` (verified via `compile_options` and a throughput benchmark).

## Testing
- `backup.sh` verified end-to-end with a stubbed `mc` and a live writer hammering the DB during backup: snapshots valid (`integrity_check: ok`), source DBs untouched, staging auto-cleaned, `--help`/zero-DB/delete-safety edge cases all pass.
- Pragmas verified to take effect on the actual better-sqlite3 build.
- `npm run typecheck` passes; full test suite (40 tests) passes via pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)